### PR TITLE
feat: 계좌 해지 시 잔액 송금 및 복구 기능 구현

### DIFF
--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -38,7 +38,8 @@ public class AccountController {
         return DeleteAccount.Response.from(
                 accountService.deleteAccount(
                         request.getUserId(),
-                        request.getAccountNumber()
+                        request.getAccountNumber(),
+                        request.getWithdrawAccountNumber()
                 )
         );
     }
@@ -61,4 +62,14 @@ public class AccountController {
             @PathVariable Long id) {
         return accountService.getAccount(id);
     }
+
+    @PostMapping("/account/restore")
+    public CreateAccount.Response restoreAccount(@RequestBody @Valid DeleteAccount.Request request) {
+        AccountDto restored = accountService.restoreAccount(
+                request.getUserId(),
+                request.getAccountNumber()
+        );
+        return CreateAccount.Response.from(restored);
+    }
+
 }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -63,12 +63,12 @@ public class AccountController {
         return accountService.getAccount(id);
     }
 
-    @PostMapping("/account/restore")
-    public CreateAccount.Response restoreAccount(@RequestBody @Valid DeleteAccount.Request request) {
-        AccountDto restored = accountService.restoreAccount(
-                request.getUserId(),
-                request.getAccountNumber()
-        );
+    @PostMapping("/accounts/{accountNumber}/restore")
+    public CreateAccount.Response restoreAccount(
+            @PathVariable String accountNumber,
+            @RequestParam Long userId
+    ) {
+        AccountDto restored = accountService.restoreAccount(userId, accountNumber);
         return CreateAccount.Response.from(restored);
     }
 

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -5,11 +5,10 @@ import com.track.fin.type.AccountStatus;
 import com.track.fin.type.AccountType;
 import com.track.fin.type.ErrorCode;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 import static com.track.fin.type.AccountStatus.LOCKED;
 import static com.track.fin.type.AccountType.LOANS;
@@ -41,6 +40,9 @@ public class Account {
     @Enumerated(EnumType.STRING)
     private AccountType accountType;
 
+    private LocalDateTime unregisteredAt;
+
+    @Setter
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus;
 
@@ -71,6 +73,16 @@ public class Account {
             throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
         }
         this.balance -= amount;
+    }
+
+    public void close() {
+        this.accountStatus = AccountStatus.CLOSED;
+        this.unregisteredAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.accountStatus = AccountStatus.ACTIVE;
+        this.unregisteredAt = null;
     }
 
 }

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -15,8 +15,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-import static com.track.fin.type.AccountStatus.CLOSED;
-import static com.track.fin.type.AccountStatus.LOCKED;
+import static com.track.fin.type.AccountStatus.*;
 import static com.track.fin.type.AccountType.LOANS;
 import static com.track.fin.type.ErrorCode.AMOUNT_EXCEED_BALANCE;
 
@@ -50,9 +49,16 @@ public class Account {
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus;
 
+    private Long lockedAmount = 0L;
+
     public void useBalance(Long amount) {
         if (accountStatus == LOCKED) {
-            // TODO: 담보 받은 금액 외에 사용 가능
+            Long availableBalance = balance - lockedAmount;
+
+            if (availableBalance < amount) {
+                throw new AccountException(AMOUNT_EXCEED_BALANCE);
+            }
+            balance -= amount;
             return;
         }
         if (amount > balance) {
@@ -64,6 +70,8 @@ public class Account {
     public void afterLoan() {
         accountType = LOANS;
         accountStatus = LOCKED;
+        // 대출 생성시 추가 예정
+//       lockedAmount = collateralAmount;
     }
 
     public void deposit(Long amount) {
@@ -83,8 +91,9 @@ public class Account {
     }
 
     public void restore() {
-        this.accountStatus = AccountStatus.ACTIVE;
+        this.accountStatus = ACTIVE;
         this.unregisteredAt = null;
+    }
 
     @Builder
     private Account(Long id, User user, String accountNumber, Long balance, Long minBalance, Boolean autoTransfer, AccountType accountType, AccountStatus accountStatus) {
@@ -98,5 +107,4 @@ public class Account {
         this.accountStatus = accountStatus;
 
     }
-
 }

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -10,8 +10,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+import static com.track.fin.type.AccountStatus.CLOSED;
 import static com.track.fin.type.AccountStatus.LOCKED;
 import static com.track.fin.type.AccountType.LOANS;
+import static com.track.fin.type.ErrorCode.AMOUNT_EXCEED_BALANCE;
 
 @Getter
 @NoArgsConstructor
@@ -52,7 +54,7 @@ public class Account {
             return;
         }
         if (amount > balance) {
-            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+            throw new AccountException(AMOUNT_EXCEED_BALANCE);
         }
         balance -= amount;
     }
@@ -70,13 +72,13 @@ public class Account {
 
     public void withdraw(Long amount) {
         if (this.balance < amount) {
-            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+            throw new AccountException(AMOUNT_EXCEED_BALANCE);
         }
         this.balance -= amount;
     }
 
     public void close() {
-        this.accountStatus = AccountStatus.CLOSED;
+        this.accountStatus = CLOSED;
         this.unregisteredAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -3,7 +3,6 @@ package com.track.fin.domain;
 import com.track.fin.exception.AccountException;
 import com.track.fin.type.AccountStatus;
 import com.track.fin.type.AccountType;
-import com.track.fin.type.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/track/fin/domain/User.java
+++ b/src/main/java/com/track/fin/domain/User.java
@@ -26,7 +26,7 @@ public class User {
 
     private String phone;
 
-    private String login_id;
+    private String loginId;
 
     private String password;
 

--- a/src/main/java/com/track/fin/dto/DeleteAccount.java
+++ b/src/main/java/com/track/fin/dto/DeleteAccount.java
@@ -25,6 +25,8 @@ public class DeleteAccount {
         @NotBlank
         @Size(min = 10, max = 10)
         private String accountNumber;
+
+        private String withdrawAccountNumber;
     }
 
     @Getter
@@ -46,4 +48,5 @@ public class DeleteAccount {
                     .build();
         }
     }
+
 }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -19,8 +19,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.track.fin.type.AccountStatus.CLOSED;
+import static com.track.fin.type.AccountStatus.ACTIVE;
 import static com.track.fin.type.ErrorCode.*;
-
 
 @Service
 @RequiredArgsConstructor
@@ -84,13 +84,9 @@ public class AccountService {
 
         validateDeleteAccount(user, closingAccount, withdrawAccount);
 
-        // 여기서 검증할 필요가 있나?
-        if (closingAccount.getBalance() > 0) {
-            transactionService.transfer(userId, accountNumber, withdrawAccountNumber, closingAccount.getBalance());
-        }
+        transactionService.transfer(userId, accountNumber, withdrawAccountNumber, closingAccount.getBalance());
 
         closingAccount.close();
-        closingAccount.setAccountStatus(CLOSED);
 
         return AccountRecord.from(accountRepository.save(closingAccount));
     }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ public class AccountService {
     private final UserService userService;
     private final AccountRepository accountRepository;
     private final UserRepository userRepository;
+    private final TransactionService transactionService;
 
     @Transactional
     public AccountDto createAccount(Long userId, Long initialBalance, AccountType accountType) {
@@ -75,19 +77,23 @@ public class AccountService {
     }
 
     @Transactional
-    public AccountDto deleteAccount(Long userId, String accountNumber) {
+    public AccountDto deleteAccount(Long userId, String accountNumber, String withdrawAccountNumber) {
         User user = userService.get(userId);
-        Account account = accountRepository.findByAccountNumber(accountNumber)
-                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account closingAccount = getAccountByNumber(accountNumber);
+        Account withdrawAccount = getAccountByNumber(withdrawAccountNumber);
 
-        validateDeleteAccount(user, account);
-        account.afterLoan();
+        validateDeleteAccount(user, closingAccount, withdrawAccount);
 
-        return AccountRecord.from(accountRepository.save(account));
+        if (closingAccount.getBalance() > 0) {
+            transactionService.transfer(userId, accountNumber, withdrawAccountNumber, closingAccount.getBalance());
+        }
+
+        closingAccount.setAccountStatus(CLOSED);
+
+        return AccountRecord.from(accountRepository.save(closingAccount));
     }
 
     @Transactional
-
     public List<AccountDto> getAccountsByuserId(Long userId) {
         User user = userService.get(userId);
 
@@ -104,16 +110,18 @@ public class AccountService {
         }
     }
 
-
-    private void validateDeleteAccount(User user, Account account) {
-        if (!Objects.equals(user.getId(), account.getUser().getId())) {
+    private void validateDeleteAccount(User user, Account closingAccount, Account withdrawAccount) {
+        if (!Objects.equals(user.getId(), closingAccount.getUser().getId())) {
             throw new AccountException(USER_ACCOUNT_UNMATCH);
         }
-        if (account.getAccountStatus() == CLOSED) {
+        if (closingAccount.getAccountStatus() == CLOSED) {
             throw new AccountException(ACCOUNT_ALREADY_UNREGISTERED);
         }
-        if (account.getBalance() > 0) {
-            throw new AccountException(BALANCE_NOT_EMPTY);
+        if (!Objects.equals(user.getId(), withdrawAccount.getUser().getId())) {
+            throw new AccountException(WITHDRAW_ACCOUNT_UNMATCH);
+        }
+        if (withdrawAccount.getAccountStatus() != ACTIVE) {
+            throw new AccountException(WITHDRAW_ACCOUNT_INACTIVE);
         }
     }
 
@@ -129,6 +137,32 @@ public class AccountService {
 
     private String generateUniqueAccountNumber() {
         return String.valueOf(1000000000L + Math.random() * 9000000000L);
+    }
+
+    @Transactional
+    public AccountDto restoreAccount(Long userId, String accountNumber) {
+        User user = userService.get(userId);
+        Account account = getAccountByNumber(accountNumber);
+
+        if (!Objects.equals(account.getUser().getId(), user.getId())) {
+            throw new AccountException(USER_ACCOUNT_UNMATCH);
+        }
+
+        if (account.getAccountStatus() != CLOSED) {
+            throw new AccountException(INVALID_REQUEST);
+        }
+
+        if (account.getUnregisteredAt() == null) {
+            throw new AccountException(INVALID_REQUEST);
+        }
+
+        if (account.getUnregisteredAt().isBefore(LocalDateTime.now().minusMonths(3))) {
+            accountRepository.delete(account);
+            throw new AccountException(ACCOUNT_RESTORE_EXPIRED);
+        }
+
+        account.restore();
+        return AccountRecord.from(accountRepository.save(account));
     }
 
 }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -84,11 +84,13 @@ public class AccountService {
 
         validateDeleteAccount(user, closingAccount, withdrawAccount);
 
+        // 여기서 검증할 필요가 있나?
         if (closingAccount.getBalance() > 0) {
             transactionService.transfer(userId, accountNumber, withdrawAccountNumber, closingAccount.getBalance());
         }
 
-        closingAccount.setAccountStatus(CLOSED);
+        closingAccount.close();
+
 
         return AccountRecord.from(accountRepository.save(closingAccount));
     }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -91,7 +91,6 @@ public class AccountService {
 
         closingAccount.close();
 
-
         return AccountRecord.from(accountRepository.save(closingAccount));
     }
 

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -90,6 +90,7 @@ public class AccountService {
         }
 
         closingAccount.close();
+        closingAccount.setAccountStatus(CLOSED);
 
         return AccountRecord.from(accountRepository.save(closingAccount));
     }

--- a/src/main/java/com/track/fin/type/ErrorCode.java
+++ b/src/main/java/com/track/fin/type/ErrorCode.java
@@ -23,7 +23,12 @@ public enum ErrorCode {
     FEE_NOT_FOUND("수수료 정보가 존재하지 않습니다."),
     INSUFFICIENT_BALANCE("잔액이 부족합니다."),
     MAX_DEPOSIT_LIMIT_EXCEEDED("입금 한도를 초과했습니다."),
-    LOAN_NOT_FOUND("대출 찾을 수 없습니다.");
+    LOAN_NOT_FOUND("대출 찾을 수 없습니다."),
+    WITHDRAW_ACCOUNT_UNMATCH("출금 계좌가 사용자와 일치하지 않습니다."),
+    WITHDRAW_ACCOUNT_INACTIVE("출금 계좌가 활성화 상태가 아닙니다."),
+    ACCOUNT_RESTORE_EXPIRED("계좌 복구 가능 기간이 지났습니다."),
+
+    ;
 
     private final String description;
 


### PR DESCRIPTION

## #️⃣ Issue Number
- #24 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 개발 상세 내역

### ✅  1.계좌 해지 시 잔액 자동 송금 처리
- deleteAccount(Long userId, String closingAccountNumber, String withdrawAccountNumber) 메서드 구현
- 해지할 계좌의 잔액을 출금 계좌로 이체
- 해지한 계좌 상태를 CLOSED로 변경 후 저장
- 출금 계좌와 사용자 소유 일치 및 상태 검증 로직 추가

### ✅  2.계좌 복구 기능 구현
- /account/restore API 구현
- 3개월 이내 복구 시 계좌 상태를 ACTIVE로 변경
- 3개월 초과 시 해당 계좌 영구 삭제 처리
- Account에 unregisteredAt 필드 추가 및 해지 시 저장

### ✅  3.계좌 개설 시 최소 예치금 검증 강화
- validateInitialBalance() 로직 수정
   - initialBalance < accountType.getBalance() 조건으로 검증

### ✅  4.ENUM 추가
- WITHDRAW_ACCOUNT_UNMATCH("출금 계좌가 본인 계좌가 아닙니다.")
- WITHDRAW_ACCOUNT_INACTIVE("출금 계좌가 사용 불가능한 상태입니다.")
- ACCOUNT_NOT_RECOVERABLE("계좌 복구 가능 기간이 지났습니다.")
 
