### PR TITLE
feat: 계좌 해지 제한 조건 및 거래 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -96,12 +96,12 @@ public class AccountController {
         return accountService.getAccountCollateralRate(userId, accountId);
     }
 
-    @GetMapping("/{accountNumber}/auto-transfer")
+    @GetMapping("accounts/{accountNumber}/auto-transfer")
     public boolean isAutoTransferRegistered(@PathVariable String accountNumber) {
         return autoTransferService.isAutoTransferRegistered(accountNumber);
     }
 
-    @GetMapping("/{accountNumber}/auto-transfer/validate")
+    @GetMapping("accounts/{accountNumber}/auto-transfer/validate")
     public void validateAutoTransferNotRegistered(@PathVariable String accountNumber) {
         autoTransferService.validateAutoTransferNotRegistered(accountNumber);
     }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -64,7 +64,7 @@ public class AccountController {
         );
     }
 
-    @GetMapping("accounts/{accountNumber}/transactions")
+    @GetMapping("/accounts/{accountNumber}/transactions")
     public List<TransferResponseRecord> getTransferTransactions(
             @PathVariable String accountNumber,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
@@ -88,7 +88,7 @@ public class AccountController {
                 .toList();
     }
 
-    @GetMapping("accounts/{accountId}/collateral")
+    @GetMapping("/accounts/{accountId}/collateral")
     public BigDecimal getCollateralRate(
             @PathVariable Long accountId,
             @RequestParam("userId") Long userId
@@ -96,12 +96,12 @@ public class AccountController {
         return accountService.getAccountCollateralRate(userId, accountId);
     }
 
-    @GetMapping("accounts/{accountNumber}/auto-transfer")
+    @GetMapping("/accounts/{accountNumber}/auto-transfer")
     public boolean isAutoTransferRegistered(@PathVariable String accountNumber) {
         return autoTransferService.isAutoTransferRegistered(accountNumber);
     }
 
-    @GetMapping("accounts/{accountNumber}/auto-transfer/validate")
+    @GetMapping("/accounts/{accountNumber}/auto-transfer/validate")
     public void validateAutoTransferNotRegistered(@PathVariable String accountNumber) {
         autoTransferService.validateAutoTransferNotRegistered(accountNumber);
     }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -9,6 +9,7 @@ import com.track.fin.record.AccountRecord;
 import com.track.fin.record.TransferResponseRecord;
 import com.track.fin.service.AccountService;
 import com.track.fin.service.TransactionService;
+import com.track.fin.type.AccountType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -27,28 +28,12 @@ public class AccountController {
     private final TransactionService transactionService;
 
     @PostMapping("/account")
-    public CreateAccount.Response createAccount(
-            @RequestBody @Valid CreateAccount.Request request
+    public AccountRecord createAccount(
+            @RequestParam Long userId,
+            @RequestParam Long initialBalance,
+            @RequestParam AccountType accountType
     ) {
-        AccountDto accountDto = accountService.createAccount(
-                request.getUserId(),
-                request.getInitialBalance(),
-                request.getAccountType()
-        );
-        return CreateAccount.Response.from(accountDto);
-    }
-
-    @DeleteMapping("/account")
-    public DeleteAccount.Response deleteAccount(
-            @RequestBody @Valid DeleteAccount.Request request
-    ) {
-        return DeleteAccount.Response.from(
-                accountService.deleteAccount(
-                        request.getUserId(),
-                        request.getAccountNumber(),
-                        request.getWithdrawAccountNumber()
-                )
-        );
+        return accountService.createAccount(userId, initialBalance, accountType);
     }
 
     @GetMapping("/accounts")
@@ -74,7 +59,16 @@ public class AccountController {
         return accountService.getAccount(id);
     }
 
-
+    @DeleteMapping("/account")
+    public AccountRecord deleteAccount(
+            @RequestBody @Valid DeleteAccount.Request request
+    ) {
+        return accountService.deleteAccount(
+                request.getUserId(),
+                request.getAccountNumber(),
+                request.getWithdrawAccountNumber()
+        );
+    }
 
     @GetMapping("/{accountNumber}/transactions")
     public List<TransferResponseRecord> getTransferTransactions(

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -27,7 +27,7 @@ public class AccountController {
     private final AccountService accountService;
     private final TransactionService transactionService;
 
-    @PostMapping("/account")
+    @PostMapping("/accounts")
     public AccountRecord createAccount(
             @RequestParam Long userId,
             @RequestParam Long initialBalance,
@@ -41,25 +41,17 @@ public class AccountController {
             @RequestParam("userId") Long userId
     ) {
         return accountService.getAccounts(userId).stream()
-                .map(account -> new AccountRecord(
-                        account.getUser().getId(),
-                        account.getAccountNumber(),
-                        account.getBalance(),
-                        account.getAccountType(),
-                        account.getRegisterdAt(),
-                        account.getUnregisteredAt()
-                ))
-                .collect(Collectors.toList());
+                .map(AccountRecord::from)
+                .toList();
     }
 
-
-    @GetMapping("/account/{id}")
+    @GetMapping("/accounts/{id}")
     public Account getAccount(
             @PathVariable Long id) {
         return accountService.getAccount(id);
     }
 
-    @DeleteMapping("/account")
+    @DeleteMapping("/accounts")
     public AccountRecord deleteAccount(
             @RequestBody @Valid DeleteAccount.Request request
     ) {
@@ -70,7 +62,7 @@ public class AccountController {
         );
     }
 
-    @GetMapping("/{accountNumber}/transactions")
+    @GetMapping("accounts/{accountNumber}/transactions")
     public List<TransferResponseRecord> getTransferTransactions(
             @PathVariable String accountNumber,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
@@ -86,22 +78,18 @@ public class AccountController {
     }
 
     @GetMapping("/accounts/active")
-    public List<AccountInfo> getActiveAccounts(
-            @RequestParam("user_id") Long userId
+    public List<AccountRecord> getActiveAccounts(
+            @RequestParam("userId") Long userId
     ) {
         return accountService.getActiveAccounts(userId).stream()
-                .map(account -> AccountInfo.builder()
-                        .accountNumber(account.getAccountNumber())
-                        .balance(account.getBalance())
-                        .accountStatus(account.getAccountStatus())
-                        .build())
-                .collect(Collectors.toList());
+                .map(AccountRecord::from)
+                .toList();
     }
 
-    @GetMapping("/{accountId}/collateral")
+    @GetMapping("accounts/{accountId}/collateral")
     public BigDecimal getCollateralRate(
             @PathVariable Long accountId,
-            @RequestParam("user_id") Long userId
+            @RequestParam("userId") Long userId
     ) {
         return accountService.getAccountCollateralRate(userId, accountId);
     }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -83,4 +83,18 @@ public class AccountController {
         );
     }
 
+    @GetMapping("/accounts/active")
+    public List<AccountInfo> getActiveAccounts(
+            @RequestParam("user_id") Long userId
+    ) {
+        return accountService.getActiveAccounts(userId).stream()
+                .map(account -> AccountInfo.builder()
+                        .accountNumber(account.getAccountNumber())
+                        .balance(account.getBalance())
+                        .accountStatus(account.getAccountStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -5,11 +5,15 @@ import com.track.fin.dto.AccountDto;
 import com.track.fin.dto.AccountInfo;
 import com.track.fin.dto.CreateAccount;
 import com.track.fin.dto.DeleteAccount;
+import com.track.fin.record.TransferResponseRecord;
 import com.track.fin.service.AccountService;
+import com.track.fin.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,6 +22,7 @@ import java.util.stream.Collectors;
 public class AccountController {
 
     private final AccountService accountService;
+    private final TransactionService transactionService;
 
     @PostMapping("/account")
     public CreateAccount.Response createAccount(
@@ -61,6 +66,21 @@ public class AccountController {
     public Account getAccount(
             @PathVariable Long id) {
         return accountService.getAccount(id);
+    }
+
+    @GetMapping("/{accountNumber}/transactions")
+    public List<TransferResponseRecord> getTransferTransactions(
+            @PathVariable String accountNumber,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @RequestParam(defaultValue = "true") boolean sortDesc
+    ) {
+        return transactionService.getTransferTransactionsByAccount(
+                accountNumber,
+                startDate,
+                endDate,
+                sortDesc
+        );
     }
 
 }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -5,6 +5,7 @@ import com.track.fin.dto.AccountDto;
 import com.track.fin.dto.AccountInfo;
 import com.track.fin.dto.CreateAccount;
 import com.track.fin.dto.DeleteAccount;
+import com.track.fin.record.AccountRecord;
 import com.track.fin.record.TransferResponseRecord;
 import com.track.fin.service.AccountService;
 import com.track.fin.service.TransactionService;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,24 +51,30 @@ public class AccountController {
         );
     }
 
-    @GetMapping("/account")
-    public List<AccountInfo> getAccountsByUserId(
-            @RequestParam("user_id") Long userId
+    @GetMapping("/accounts")
+    public List<AccountRecord> getAccountsByUserId(
+            @RequestParam("userId") Long userId
     ) {
-        return accountService.getAccountsByuserId(userId)
-                .stream().map(accountDto ->
-                        AccountInfo.builder()
-                                .accountNumber(accountDto.getAccountNumber())
-                                .balance(accountDto.getBalance())
-                                .build())
+        return accountService.getAccounts(userId).stream()
+                .map(account -> new AccountRecord(
+                        account.getUser().getId(),
+                        account.getAccountNumber(),
+                        account.getBalance(),
+                        account.getAccountType(),
+                        account.getRegisterdAt(),
+                        account.getUnregisteredAt()
+                ))
                 .collect(Collectors.toList());
     }
+
 
     @GetMapping("/account/{id}")
     public Account getAccount(
             @PathVariable Long id) {
         return accountService.getAccount(id);
     }
+
+
 
     @GetMapping("/{accountNumber}/transactions")
     public List<TransferResponseRecord> getTransferTransactions(
@@ -96,5 +104,12 @@ public class AccountController {
                 .collect(Collectors.toList());
     }
 
+    @GetMapping("/{accountId}/collateral")
+    public BigDecimal getCollateralRate(
+            @PathVariable Long accountId,
+            @RequestParam("user_id") Long userId
+    ) {
+        return accountService.getAccountCollateralRate(userId, accountId);
+    }
 
 }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -38,7 +38,8 @@ public class AccountController {
         return DeleteAccount.Response.from(
                 accountService.deleteAccount(
                         request.getUserId(),
-                        request.getAccountNumber()
+                        request.getAccountNumber(),
+                        request.getWithdrawAccountNumber()
                 )
         );
     }
@@ -61,4 +62,5 @@ public class AccountController {
             @PathVariable Long id) {
         return accountService.getAccount(id);
     }
+
 }

--- a/src/main/java/com/track/fin/controller/AccountController.java
+++ b/src/main/java/com/track/fin/controller/AccountController.java
@@ -8,6 +8,7 @@ import com.track.fin.dto.DeleteAccount;
 import com.track.fin.record.AccountRecord;
 import com.track.fin.record.TransferResponseRecord;
 import com.track.fin.service.AccountService;
+import com.track.fin.service.AutoTransferService;
 import com.track.fin.service.TransactionService;
 import com.track.fin.type.AccountType;
 import jakarta.validation.Valid;
@@ -26,6 +27,7 @@ public class AccountController {
 
     private final AccountService accountService;
     private final TransactionService transactionService;
+    private final AutoTransferService autoTransferService;
 
     @PostMapping("/accounts")
     public AccountRecord createAccount(
@@ -92,6 +94,16 @@ public class AccountController {
             @RequestParam("userId") Long userId
     ) {
         return accountService.getAccountCollateralRate(userId, accountId);
+    }
+
+    @GetMapping("/{accountNumber}/auto-transfer")
+    public boolean isAutoTransferRegistered(@PathVariable String accountNumber) {
+        return autoTransferService.isAutoTransferRegistered(accountNumber);
+    }
+
+    @GetMapping("/{accountNumber}/auto-transfer/validate")
+    public void validateAutoTransferNotRegistered(@PathVariable String accountNumber) {
+        autoTransferService.validateAutoTransferNotRegistered(accountNumber);
     }
 
 }

--- a/src/main/java/com/track/fin/controller/AutoTransferController.java
+++ b/src/main/java/com/track/fin/controller/AutoTransferController.java
@@ -1,0 +1,22 @@
+package com.track.fin.controller;
+
+import com.track.fin.service.AutoTransferService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AutoTransferController {
+
+    private final AutoTransferService autoTransferService;
+
+    @GetMapping("/accounts/auto-transfer/{accountNumber}")
+    public boolean isAutoTransferRegistered(@PathVariable String accountNumber) {
+        return autoTransferService.isAutoTransferRegistered(accountNumber);
+    }
+
+    @GetMapping("/accounts/auto-transfer/{accountNumber}/validate")
+    public void validateAutoTransferNotRegistered(@PathVariable String accountNumber) {
+        autoTransferService.validateAutoTransferNotRegistered(accountNumber);
+    }
+}

--- a/src/main/java/com/track/fin/controller/FeeController.java
+++ b/src/main/java/com/track/fin/controller/FeeController.java
@@ -15,27 +15,27 @@ public class FeeController {
 
     private final FeeService feeService;
 
-    @PostMapping("/fee")
+    @PostMapping("/fees")
     public FeeRecord createFee(@RequestBody FeeRecord feeRecord) {
         return FeeRecord.from(feeService.createFeeByGrade(feeRecord));
     }
 
-    @GetMapping("/fee")
+    @GetMapping("/fees")
     public List<Fee> getAllFees() {
         return feeService.getAllFees();
     }
 
-    @GetMapping("fee/{gradeType}")
+    @GetMapping("fees/{gradeType}")
     public FeeRecord getFee(@PathVariable GradeType gradeType) {
         return FeeRecord.from(feeService.getFeeByGrade(gradeType));
     }
 
-    @PutMapping("fee/{id}")
+    @PutMapping("fees/{id}")
     public FeeRecord updateFee(@PathVariable Long id, @RequestBody FeeRecord feeRecord) {
         return FeeRecord.from(feeService.updateFee(id, feeRecord));
     }
 
-    @DeleteMapping("fee/{id}")
+    @DeleteMapping("fees/{id}")
     public void deleteFee(@PathVariable Long id) {
         feeService.deleteFee(id);
     }

--- a/src/main/java/com/track/fin/controller/FeeController.java
+++ b/src/main/java/com/track/fin/controller/FeeController.java
@@ -10,33 +10,32 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/fees")
 @RequiredArgsConstructor
 public class FeeController {
 
     private final FeeService feeService;
 
-    @PostMapping
+    @PostMapping("/fee")
     public FeeRecord createFee(@RequestBody FeeRecord feeRecord) {
         return FeeRecord.from(feeService.createFeeByGrade(feeRecord));
     }
 
-    @GetMapping
+    @GetMapping("/fee")
     public List<Fee> getAllFees() {
         return feeService.getAllFees();
     }
 
-    @GetMapping("/{gradeType}")
+    @GetMapping("fee/{gradeType}")
     public FeeRecord getFee(@PathVariable GradeType gradeType) {
         return FeeRecord.from(feeService.getFeeByGrade(gradeType));
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("fee/{id}")
     public FeeRecord updateFee(@PathVariable Long id, @RequestBody FeeRecord feeRecord) {
         return FeeRecord.from(feeService.updateFee(id, feeRecord));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("fee/{id}")
     public void deleteFee(@PathVariable Long id) {
         feeService.deleteFee(id);
     }

--- a/src/main/java/com/track/fin/controller/TransactionController.java
+++ b/src/main/java/com/track/fin/controller/TransactionController.java
@@ -2,14 +2,20 @@ package com.track.fin.controller;
 
 import com.track.fin.dto.CancelBalance;
 import com.track.fin.dto.QueryTransactionResponse;
+import com.track.fin.dto.TransactionDto;
 import com.track.fin.dto.UseBalance;
 import com.track.fin.exception.AccountException;
 import com.track.fin.record.*;
 import com.track.fin.service.TransactionService;
+import com.track.fin.type.TransactionType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -82,7 +88,6 @@ public class TransactionController {
         }
     }
 
-
     @PostMapping("/transaction/withdraw")
     public WithdrawalRecord withdraw(
             @Valid @RequestBody WithdrawalRequestRecord request
@@ -127,4 +132,23 @@ public class TransactionController {
             @PathVariable String transactionId) {
         return QueryTransactionResponse.from(transactionService.queryTransactionId(transactionId));
     }
+
+    @GetMapping("/{accountNumber}")
+    public List<TransactionDto> getTransactions(
+            @PathVariable String accountNumber,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+
+            @RequestParam(required = false) List<TransactionType> types,
+            @RequestParam(defaultValue = "true") boolean sortDesc
+    ) {
+        LocalDateTime from = startDate != null ? startDate : LocalDateTime.now().minusMonths(1);
+        LocalDateTime to = endDate != null ? endDate : LocalDateTime.now();
+
+        return transactionService.getTransactionsByAccount(accountNumber, from, to, types, sortDesc);
+    }
+
 }

--- a/src/main/java/com/track/fin/controller/TransactionController.java
+++ b/src/main/java/com/track/fin/controller/TransactionController.java
@@ -1,5 +1,6 @@
 package com.track.fin.controller;
 
+import com.track.fin.domain.Transaction;
 import com.track.fin.dto.CancelBalance;
 import com.track.fin.dto.QueryTransactionResponse;
 import com.track.fin.dto.TransactionDto;
@@ -107,18 +108,18 @@ public class TransactionController {
         }
     }
 
-    @PostMapping("transaction/cancel")
-    public CancelBalance.Response cancelBalance(
+    @PostMapping("/transaction/cancel")
+    public TransferResponseRecord cancelBalance(
             @Valid @RequestBody CancelBalance.Request request
     ) {
         try {
-            return CancelBalance.Response.from(
-                    transactionService.cancelBalance(String.valueOf(request.getTransactionId()),
-                            request.getAccountNumber(), request.getAmount())
+            return transactionService.cancelBalance(
+                    String.valueOf(request.getTransactionId()),
+                    request.getAccountNumber(),
+                    request.getAmount()
             );
         } catch (AccountException e) {
-            log.error("Failed to use balance. ");
-
+            log.error("Cancel failed", e);
             transactionService.saveFailedCancelTransaction(
                     request.getAccountNumber(),
                     request.getAmount()
@@ -128,27 +129,9 @@ public class TransactionController {
     }
 
     @GetMapping("/transaction/{transactionId}")
-    public QueryTransactionResponse queryTransaction(
+    public TransferResponseRecord queryTransaction(
             @PathVariable String transactionId) {
-        return QueryTransactionResponse.from(transactionService.queryTransactionId(transactionId));
-    }
-
-    @GetMapping("/{accountNumber}")
-    public List<TransactionDto> getTransactions(
-            @PathVariable String accountNumber,
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
-
-            @RequestParam(required = false) List<TransactionType> types,
-            @RequestParam(defaultValue = "true") boolean sortDesc
-    ) {
-        LocalDateTime from = startDate != null ? startDate : LocalDateTime.now().minusMonths(1);
-        LocalDateTime to = endDate != null ? endDate : LocalDateTime.now();
-
-        return transactionService.getTransactionsByAccount(accountNumber, from, to, types, sortDesc);
+        return transactionService.queryTransactionId(transactionId);
     }
 
 }

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -5,12 +5,12 @@ import com.track.fin.type.AccountStatus;
 import com.track.fin.type.AccountType;
 import com.track.fin.type.ErrorCode;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
+import static com.track.fin.type.AccountStatus.CLOSED;
 import static com.track.fin.type.AccountStatus.LOCKED;
 import static com.track.fin.type.AccountType.LOANS;
 
@@ -42,7 +42,10 @@ public class Account {
     private AccountType accountType;
 
     @Enumerated(EnumType.STRING)
+    @Setter
     private AccountStatus accountStatus;
+
+    private LocalDateTime unregisteredAt;
 
     public void useBalance(Long amount) {
         if (accountStatus == LOCKED) {
@@ -71,6 +74,11 @@ public class Account {
             throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
         }
         this.balance -= amount;
+    }
+
+    public void close() {
+        this.accountStatus = CLOSED;
+        this.unregisteredAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/track/fin/domain/Account.java
+++ b/src/main/java/com/track/fin/domain/Account.java
@@ -45,7 +45,9 @@ public class Account {
     @Setter
     private AccountStatus accountStatus;
 
+    private LocalDateTime registerdAt;
     private LocalDateTime unregisteredAt;
+
 
     public void useBalance(Long amount) {
         if (accountStatus == LOCKED) {

--- a/src/main/java/com/track/fin/dto/DeleteAccount.java
+++ b/src/main/java/com/track/fin/dto/DeleteAccount.java
@@ -25,6 +25,7 @@ public class DeleteAccount {
         @NotBlank
         @Size(min = 10, max = 10)
         private String accountNumber;
+        private String withdrawAccountNumber;
     }
 
     @Getter

--- a/src/main/java/com/track/fin/record/AccountRecord.java
+++ b/src/main/java/com/track/fin/record/AccountRecord.java
@@ -1,7 +1,6 @@
 package com.track.fin.record;
 
 import com.track.fin.domain.Account;
-import com.track.fin.dto.AccountDto;
 import com.track.fin.type.AccountType;
 
 import java.time.LocalDateTime;
@@ -17,13 +16,15 @@ public record AccountRecord(
 
 ) {
 
-    public static AccountDto from(Account account) {
-        return AccountDto.builder()
-                .userId(account.getUser().getId())
-                .accountNumber(account.getAccountNumber())
-                .balance(account.getBalance())
-                .accountType(account.getAccountType())
-                .build();
+    public static AccountRecord from(Account account) {
+        return new AccountRecord(
+                account.getUser().getId(),
+                account.getAccountNumber(),
+                account.getBalance(),
+                account.getAccountType(),
+                account.getRegisterdAt(),
+                account.getUnregisteredAt()
+        );
     }
 
 }

--- a/src/main/java/com/track/fin/record/AccountRecord.java
+++ b/src/main/java/com/track/fin/record/AccountRecord.java
@@ -1,6 +1,7 @@
 package com.track.fin.record;
 
 import com.track.fin.domain.Account;
+import com.track.fin.type.AccountStatus;
 import com.track.fin.type.AccountType;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public record AccountRecord(
         String accountNumber,
         Long balance,
         AccountType accountType,
+        AccountStatus accountStatus,         // ✅ 추가
         LocalDateTime registeredAt,
         LocalDateTime unregisteredAt
 
@@ -22,6 +24,7 @@ public record AccountRecord(
                 account.getAccountNumber(),
                 account.getBalance(),
                 account.getAccountType(),
+                account.getAccountStatus(),
                 account.getRegisterdAt(),
                 account.getUnregisteredAt()
         );

--- a/src/main/java/com/track/fin/record/AccountRecord.java
+++ b/src/main/java/com/track/fin/record/AccountRecord.java
@@ -12,7 +12,7 @@ public record AccountRecord(
         String accountNumber,
         Long balance,
         AccountType accountType,
-        AccountStatus accountStatus,         // ✅ 추가
+        AccountStatus accountStatus,
         LocalDateTime registeredAt,
         LocalDateTime unregisteredAt
 

--- a/src/main/java/com/track/fin/record/TransferResponseRecord.java
+++ b/src/main/java/com/track/fin/record/TransferResponseRecord.java
@@ -28,4 +28,16 @@ public record TransferResponseRecord(
         );
     }
 
+    public static TransferResponseRecord from(Transaction transaction) {
+        return new TransferResponseRecord(
+                transaction.getId(),
+                transaction.getAccount().getAccountNumber(),
+                null,
+                transaction.getAmount(),
+                transaction.getBalanceSnapshot(),
+                null,
+                transaction.getTransactionDate()
+        );
+    }
+
 }

--- a/src/main/java/com/track/fin/record/TransferResponseRecord.java
+++ b/src/main/java/com/track/fin/record/TransferResponseRecord.java
@@ -2,6 +2,8 @@ package com.track.fin.record;
 
 import com.track.fin.domain.Transaction;
 
+import java.time.LocalDateTime;
+
 public record TransferResponseRecord(
 
         String transactionId,
@@ -9,7 +11,8 @@ public record TransferResponseRecord(
         String toAccountNumber,
         Long amount,
         Long fromBalanceSnapshot,
-        Long toBalanceSnapshot
+        Long toBalanceSnapshot,
+        LocalDateTime transactionDate
 
 ) {
 
@@ -20,7 +23,8 @@ public record TransferResponseRecord(
                 toTransaction.getAccount().getAccountNumber(),
                 fromTransaction.getAmount(),
                 fromTransaction.getBalanceSnapshot(),
-                toTransaction.getBalanceSnapshot()
+                toTransaction.getBalanceSnapshot(),
+                fromTransaction.getTransactionDate()
         );
     }
 

--- a/src/main/java/com/track/fin/repository/AccountRepository.java
+++ b/src/main/java/com/track/fin/repository/AccountRepository.java
@@ -26,5 +26,4 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     List<Account> findByUserAndAccountStatus(User user, AccountStatus status);
 
-
 }

--- a/src/main/java/com/track/fin/repository/AccountRepository.java
+++ b/src/main/java/com/track/fin/repository/AccountRepository.java
@@ -2,6 +2,7 @@ package com.track.fin.repository;
 
 import com.track.fin.domain.Account;
 import com.track.fin.domain.User;
+import com.track.fin.type.AccountStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -22,5 +23,8 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsByAccountNumber(String accountNumber);
 
     List<Account> findByUserId(Long userId);
+
+    List<Account> findByUserAndAccountStatus(User user, AccountStatus status);
+
 
 }

--- a/src/main/java/com/track/fin/repository/LoanRepository.java
+++ b/src/main/java/com/track/fin/repository/LoanRepository.java
@@ -1,7 +1,11 @@
 package com.track.fin.repository;
 
+import com.track.fin.domain.Account;
 import com.track.fin.domain.Loan;
+import com.track.fin.type.LoanStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LoanRepository extends JpaRepository<Loan, Long> {
+
+    boolean existsByAccountAndLoanStatusNot(Account account, LoanStatus loanStatus);
 }

--- a/src/main/java/com/track/fin/repository/TransactionRepository.java
+++ b/src/main/java/com/track/fin/repository/TransactionRepository.java
@@ -31,4 +31,11 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
             LocalDateTime endDate
     );
 
+    List<Transaction> findByAccountAndTransactionTypeAndTransactionDateBetween(
+            Account account,
+            TransactionType transactionType,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
+
 }

--- a/src/main/java/com/track/fin/repository/TransactionRepository.java
+++ b/src/main/java/com/track/fin/repository/TransactionRepository.java
@@ -1,14 +1,34 @@
 package com.track.fin.repository;
 
+import com.track.fin.domain.Account;
 import com.track.fin.domain.Transaction;
+import com.track.fin.type.TransactionMethodType;
+import com.track.fin.type.TransactionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
     Optional<Transaction> findById(String transactionId);
+
+    boolean existsByAccountAndTransactionMethodType(Account account, TransactionMethodType methodType);
+
+    List<Transaction> findByAccountAndTransactionDateBetweenAndTransactionTypeIn(
+            Account account,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            List<TransactionType> types
+    );
+
+    List<Transaction> findByAccountAndTransactionDateBetween(
+            Account account,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
 
 }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -87,10 +87,7 @@ public class AccountService {
 
         Account withdrawAccount = getAccountByNumber(withdrawAccountNumber);
 
-
         validatePendingLoanOrAutoTransfer(closingAccount);
-
-
         validateDeleteAccount(user, closingAccount, withdrawAccount);
 
         if (closingAccount.getBalance() > 0) {
@@ -98,6 +95,7 @@ public class AccountService {
         }
 
         closingAccount.setAccountStatus(CLOSED);
+        closingAccount.close();
 
         return AccountRecord.from(accountRepository.save(closingAccount));
     }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -6,13 +6,13 @@ import com.track.fin.dto.AccountDto;
 import com.track.fin.exception.AccountException;
 import com.track.fin.record.AccountRecord;
 import com.track.fin.repository.AccountRepository;
-import com.track.fin.repository.UserRepository;
 import com.track.fin.type.AccountType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -28,7 +28,9 @@ public class AccountService {
 
     private final UserService userService;
     private final AccountRepository accountRepository;
-    private final UserRepository userRepository;
+    private final AutoTransferService autoTransferService;
+    private final LoanService loanService;
+    private final TransactionService transactionService;
 
     @Transactional
     public AccountDto createAccount(Long userId, Long initialBalance, AccountType accountType) {
@@ -75,19 +77,32 @@ public class AccountService {
     }
 
     @Transactional
-    public AccountDto deleteAccount(Long userId, String accountNumber) {
+    public AccountDto deleteAccount(Long userId, String closingAccountNumber, String withdrawAccountNumber) {
         User user = userService.get(userId);
-        Account account = accountRepository.findByAccountNumber(accountNumber)
-                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account closingAccount = getAccountByNumber(closingAccountNumber);
 
-        validateDeleteAccount(user, account);
-        account.afterLoan();
+        if (withdrawAccountNumber == null || withdrawAccountNumber.isBlank()) {
+            throw new AccountException(WITHDRAW_ACCOUNT_NOT_PROVIDED);
+        }
 
-        return AccountRecord.from(accountRepository.save(account));
+        Account withdrawAccount = getAccountByNumber(withdrawAccountNumber);
+
+
+        validatePendingLoanOrAutoTransfer(closingAccount);
+
+
+        validateDeleteAccount(user, closingAccount, withdrawAccount);
+
+        if (closingAccount.getBalance() > 0) {
+            transactionService.transfer(userId, closingAccountNumber, withdrawAccountNumber, closingAccount.getBalance());
+        }
+
+        closingAccount.setAccountStatus(CLOSED);
+
+        return AccountRecord.from(accountRepository.save(closingAccount));
     }
 
     @Transactional
-
     public List<AccountDto> getAccountsByuserId(Long userId) {
         User user = userService.get(userId);
 
@@ -102,17 +117,33 @@ public class AccountService {
         if (accountRepository.countByUser(user) == 10) {
             throw new AccountException(MAX_ACCOUNT_PER_USER_10);
         }
+
+        boolean hasRecentClosedAccount = accountRepository.findByUser(user).stream()
+                .anyMatch(account ->
+                        account.getAccountStatus() == CLOSED &&
+                                account.getUnregisteredAt() != null &&
+                                account.getUnregisteredAt().isAfter(LocalDateTime.now().minusMonths(1))
+                );
+
+        if (hasRecentClosedAccount) {
+            throw new AccountException(CANNOT_CREATE_ACCOUNT_DUE_TO_RECENT_CLOSURE);
+        }
     }
 
-
-    private void validateDeleteAccount(User user, Account account) {
-        if (!Objects.equals(user.getId(), account.getUser().getId())) {
+    private void validateDeleteAccount(User user, Account closingAccount, Account withdrawAccount) {
+        if (!Objects.equals(user.getId(), closingAccount.getUser().getId())) {
             throw new AccountException(USER_ACCOUNT_UNMATCH);
         }
-        if (account.getAccountStatus() == CLOSED) {
+        if (closingAccount.getAccountStatus() == CLOSED) {
             throw new AccountException(ACCOUNT_ALREADY_UNREGISTERED);
         }
-        if (account.getBalance() > 0) {
+        if (!Objects.equals(user.getId(), withdrawAccount.getUser().getId())) {
+            throw new AccountException(WITHDRAW_ACCOUNT_UNMATCH);
+        }
+        if (withdrawAccount.getAccountStatus() != ACTIVE) {
+            throw new AccountException(WITHDRAW_ACCOUNT_INACTIVE);
+        }
+        if (closingAccount.getBalance() > 0) {
             throw new AccountException(BALANCE_NOT_EMPTY);
         }
     }
@@ -120,6 +151,18 @@ public class AccountService {
     private void validateInitialBalance(Long initialBalance, AccountType accountType) {
         if (accountType.getBalance().equals(initialBalance)) {
             throw new AccountException(INSUFFICIENT_INITIAL_BALANCE);
+        }
+    }
+
+    private void validatePendingLoanOrAutoTransfer(Account account) {
+        boolean hasLoan = loanService.existsUnpaidLoanByAccount(account);
+        boolean hasAutoTransfer = autoTransferService.existsByAccount(account);
+
+        if (hasLoan) {
+            throw new AccountException(LOAN_EXISTS);
+        }
+        if (hasAutoTransfer) {
+            throw new AccountException(AUTO_TRANSFER_EXISTS);
         }
     }
 

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -116,16 +116,20 @@ public class AccountService {
             throw new AccountException(MAX_ACCOUNT_PER_USER_10);
         }
 
-        boolean hasRecentClosedAccount = accountRepository.findByUser(user).stream()
-                .anyMatch(account ->
-                        account.getAccountStatus() == CLOSED &&
-                                account.getUnregisteredAt() != null &&
-                                account.getUnregisteredAt().isAfter(LocalDateTime.now().minusMonths(1))
-                );
-
-        if (hasRecentClosedAccount) {
+        if (hasClosedAccountWithinLastMonth(user)) {
             throw new AccountException(CANNOT_CREATE_ACCOUNT_DUE_TO_RECENT_CLOSURE);
         }
+    }
+
+    private boolean hasClosedAccountWithinLastMonth(User user) {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+
+        return accountRepository.findByUser(user).stream()
+                .filter(account -> account.getAccountStatus() == CLOSED)
+                .anyMatch(account -> {
+                    LocalDateTime closedAt = account.getUnregisteredAt();
+                    return closedAt != null && closedAt.isAfter(oneMonthAgo);
+                });
     }
 
     private void validateDeleteAccount(User user, Account closingAccount, Account withdrawAccount) {

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -176,4 +176,11 @@ public class AccountService {
         return String.valueOf(1000000000L + Math.random() * 9000000000L);
     }
 
+    @Transactional(readOnly = true)
+    public List<Account> getActiveAccounts(Long userId) {
+        User user = userService.get(userId);
+        return accountRepository.findByUserAndAccountStatus(user, ACTIVE);
+    }
+
+
 }

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -8,6 +8,7 @@ import com.track.fin.record.AccountRecord;
 import com.track.fin.repository.AccountRepository;
 import com.track.fin.type.AccountType;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,9 @@ import static com.track.fin.type.ErrorCode.*;
 @RequiredArgsConstructor
 public class AccountService {
 
+    private static final long ACCOUNT_NUMBER_BASE = 1_000_000_000L;
+    private static final long ACCOUNT_NUMBER_RANGE = 9_000_000_000L;
+
     private final UserService userService;
     private final AccountRepository accountRepository;
     private final AutoTransferService autoTransferService;
@@ -33,7 +37,7 @@ public class AccountService {
     private final TransactionService transactionService;
 
     @Transactional
-    public AccountDto createAccount(Long userId, Long initialBalance, AccountType accountType) {
+    public AccountRecord createAccount(Long userId, Long initialBalance, AccountType accountType) {
         User user = userService.get(userId);
 
         validateCreateAccount(user);
@@ -77,7 +81,7 @@ public class AccountService {
     }
 
     @Transactional
-    public AccountDto deleteAccount(Long userId, String closingAccountNumber, String withdrawAccountNumber) {
+    public AccountRecord deleteAccount(Long userId, String closingAccountNumber, String withdrawAccountNumber) {
         User user = userService.get(userId);
         Account closingAccount = getAccountByNumber(closingAccountNumber);
 
@@ -95,20 +99,8 @@ public class AccountService {
         }
 
         closingAccount.setAccountStatus(CLOSED);
-        closingAccount.close();
 
         return AccountRecord.from(accountRepository.save(closingAccount));
-    }
-
-    @Transactional
-    public List<AccountDto> getAccountsByuserId(Long userId) {
-        User user = userService.get(userId);
-
-        List<Account> accounts = accountRepository.findByUser(user);
-
-        return accounts.stream()
-                .map(AccountRecord::from)
-                .collect(Collectors.toList());
     }
 
     private void validateCreateAccount(User user) {
@@ -173,7 +165,8 @@ public class AccountService {
     }
 
     private String generateUniqueAccountNumber() {
-        return String.valueOf(1000000000L + Math.random() * 9000000000L);
+        long randomNumber = (long) (Math.random() * ACCOUNT_NUMBER_RANGE);
+        return String.valueOf(ACCOUNT_NUMBER_BASE + randomNumber);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/track/fin/service/AccountService.java
+++ b/src/main/java/com/track/fin/service/AccountService.java
@@ -182,5 +182,4 @@ public class AccountService {
         return accountRepository.findByUserAndAccountStatus(user, ACTIVE);
     }
 
-
 }

--- a/src/main/java/com/track/fin/service/AutoTransferService.java
+++ b/src/main/java/com/track/fin/service/AutoTransferService.java
@@ -1,0 +1,43 @@
+package com.track.fin.service;
+
+import com.track.fin.domain.Account;
+import com.track.fin.exception.AccountException;
+import com.track.fin.repository.AccountRepository;
+import com.track.fin.repository.TransactionRepository;
+import com.track.fin.type.TransactionMethodType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.track.fin.type.ErrorCode.AUTO_TRANSFER_ACTIVE;
+
+@Service
+@RequiredArgsConstructor
+public class AutoTransferService {
+
+    private final AccountRepository accountRepository;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional(readOnly = true)
+    public void validateAutoTransferNotRegistered(String accountNumber) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(AUTO_TRANSFER_ACTIVE));
+
+        if (Boolean.TRUE.equals(account.getAutoTransfer())) {
+            throw new AccountException(AUTO_TRANSFER_ACTIVE);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isAutoTransferRegistered(String accountNumber) {
+        return accountRepository.findByAccountNumber(accountNumber)
+                .map(Account::getAutoTransfer)
+                .orElse(false);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByAccount(Account account) {
+        return transactionRepository.existsByAccountAndTransactionMethodType(account, TransactionMethodType.AUTO);
+    }
+
+}

--- a/src/main/java/com/track/fin/service/LoanService.java
+++ b/src/main/java/com/track/fin/service/LoanService.java
@@ -5,27 +5,31 @@ import com.track.fin.domain.Loan;
 import com.track.fin.domain.User;
 import com.track.fin.exception.AccountException;
 import com.track.fin.record.CreateLoanRecord;
+import com.track.fin.repository.AccountRepository;
 import com.track.fin.repository.LoanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.track.fin.type.ErrorCode.ACCOUNT_NOT_FOUND;
 import static com.track.fin.type.ErrorCode.LOAN_NOT_FOUND;
-
+import static com.track.fin.type.LoanStatus.REPAID;
 @Service
 @RequiredArgsConstructor
 public class LoanService {
 
     private final UserService userService;
-    private final AccountService accountService;
+    private final AccountRepository accountRepository;
     private final LoanRepository loanRepository;
 
     @Transactional
     public Loan createLoan(CreateLoanRecord createLoan) {
         User user = userService.get(createLoan.userId());
 
-        Account account = accountService.getAccount(createLoan.accountId());
+        Account account = accountRepository.findById(createLoan.accountId())
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         account.afterLoan();
+
 
         Loan loan = Loan.from(user, account, createLoan);
         return loanRepository.save(loan);
@@ -41,7 +45,8 @@ public class LoanService {
     public Loan updateLoan(Long loanId, CreateLoanRecord updateLoan) {
         Loan loan = getLoan(loanId);
 
-        Account account = accountService.getAccount(updateLoan.accountId());
+        Account account = accountRepository.findById(updateLoan.accountId())
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         User user = userService.get(updateLoan.userId());
 
         loan.update(user, account, updateLoan);
@@ -53,6 +58,10 @@ public class LoanService {
     public void deleteLoan(Long loanId) {
         Loan loan = getLoan(loanId);
         loanRepository.delete(loan);
+    }
+
+    public boolean existsUnpaidLoanByAccount(Account account) {
+        return loanRepository.existsByAccountAndLoanStatusNot(account, REPAID);
     }
 
 }

--- a/src/main/java/com/track/fin/service/TransactionService.java
+++ b/src/main/java/com/track/fin/service/TransactionService.java
@@ -6,7 +6,9 @@ import com.track.fin.domain.User;
 import com.track.fin.dto.TransactionDto;
 import com.track.fin.exception.AccountException;
 import com.track.fin.record.TransferResponseRecord;
+import com.track.fin.repository.AccountRepository;
 import com.track.fin.repository.TransactionRepository;
+import com.track.fin.repository.UserRepository;
 import com.track.fin.type.AccountStatus;
 import com.track.fin.type.TransactionResultType;
 import com.track.fin.type.TransactionType;
@@ -15,8 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.track.fin.type.ErrorCode.*;
 import static com.track.fin.type.TransactionResultType.FAIL;
@@ -29,18 +35,22 @@ import static com.track.fin.type.TransactionType.*;
 public class TransactionService {
 
     private final TransactionRepository transactionRepository;
-    private final UserService userService;
-    private final AccountService accountService;
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public TransactionDto useBalance(Long userId, String accountNumber, Long amount) {
-        User user = userService.get(userId);
-        Account account = accountService.getAccountByNumber(accountNumber);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
 
         validateUserBalance(user, account, amount);
         account.useBalance(amount);
 
-        return TransactionDto.fromEntity(saveAndGetTransaction(DEPOSIT, SUCCESS, account, amount));
+        return TransactionDto.fromEntity(
+                saveAndGetTransaction(DEPOSIT, SUCCESS, account, amount)
+        );
     }
 
     private Transaction saveAndGetTransaction(TransactionType type, TransactionResultType result, Account account, Long amount) {
@@ -56,8 +66,41 @@ public class TransactionService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public List<TransactionDto> getTransactionsByAccount(
+            String accountNumber,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            List<TransactionType> types,
+            boolean sortDesc
+    ) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+
+        List<Transaction> transactions = (types == null || types.isEmpty()) ?
+                transactionRepository.findByAccountAndTransactionDateBetween(
+                        account, startDate, endDate
+                )
+                : transactionRepository.findByAccountAndTransactionDateBetweenAndTransactionTypeIn(
+                account, startDate, endDate, types
+        );
+
+        transactions.sort((a, b) -> {
+            if (sortDesc) {
+                return b.getTransactionDate().compareTo(a.getTransactionDate());
+            } else {
+                return a.getTransactionDate().compareTo(b.getTransactionDate());
+            }
+        });
+
+        return transactions.stream()
+                .map(TransactionDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
     public void saveFailedUseTransaction(String accountNumber, Long amount) {
-        Account account = accountService.getAccountByNumber(accountNumber);
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         saveAndGetTransaction(DEPOSIT, FAIL, account, amount);
     }
 
@@ -65,7 +108,8 @@ public class TransactionService {
     public TransactionDto cancelBalance(String transactionId, String accountNumber, Long amount) {
         Transaction transaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new AccountException(TRANSACTION_NOT_FOUND));
-        Account account = accountService.getAccountByNumber(accountNumber);
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
 
         validateCancelBalance(transaction, account, amount);
         account.useBalance(amount);
@@ -74,7 +118,8 @@ public class TransactionService {
     }
 
     public void saveFailedCancelTransaction(String accountNumber, Long amount) {
-        Account account = accountService.getAccountByNumber(accountNumber);
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         saveAndGetTransaction(DEPOSIT, FAIL, account, amount);
     }
 
@@ -108,8 +153,10 @@ public class TransactionService {
 
     @Transactional
     public Transaction deposit(Long userId, String accountNumber, Long amount) {
-        User user = userService.get(userId);
-        Account account = accountService.getAccountByNumber(accountNumber);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
 
         validateDeposit(user, account);
         account.deposit(amount);
@@ -118,7 +165,8 @@ public class TransactionService {
     }
 
     public void saveFailedDepositTransaction(String accountNumber, Long amount) {
-        Account account = accountService.getAccountByNumber(accountNumber);
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         saveAndGetTransaction(DEPOSIT, FAIL, account, amount);
     }
 
@@ -133,8 +181,10 @@ public class TransactionService {
 
     @Transactional
     public Transaction withdraw(Long userId, String accountNumber, Long amount) {
-        User user = userService.get(userId);
-        Account account = accountService.getAccountByNumber(accountNumber);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
 
         validateWithdraw(user, account, amount);
         account.withdraw(amount);
@@ -143,7 +193,8 @@ public class TransactionService {
     }
 
     public void saveFailedWithdrawTransaction(String accountNumber, Long amount) {
-        Account account = accountService.getAccountByNumber(accountNumber);
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         saveAndGetTransaction(WITHDRAWAL, FAIL, account, amount);
     }
 
@@ -161,9 +212,12 @@ public class TransactionService {
 
     @Transactional
     public TransferResponseRecord transfer(Long userId, String fromAccountNumber, String toAccountNumber, Long amount) {
-        User user = userService.get(userId);
-        Account fromAccount = accountService.getAccountByNumber(fromAccountNumber);
-        Account toAccount = accountService.getAccountByNumber(toAccountNumber);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account fromAccount = accountRepository.findByAccountNumber(fromAccountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+        Account toAccount = accountRepository.findByAccountNumber(toAccountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
 
         validateTransfer(user, fromAccount, toAccount, amount);
 
@@ -177,8 +231,10 @@ public class TransactionService {
     }
 
     public void saveFailedTransferTransaction(String fromAccountNumber, String toAccountNumber, Long amount) {
-        Account fromAccount = accountService.getAccountByNumber(fromAccountNumber);
-        Account toAccount = accountService.getAccountByNumber(toAccountNumber);
+        Account fromAccount = accountRepository.findByAccountNumber(fromAccountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+        Account toAccount = accountRepository.findByAccountNumber(toAccountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
         saveAndGetTransaction(TRANSFER, FAIL, fromAccount, amount);
         saveAndGetTransaction(TRANSFER, FAIL, toAccount, amount);
     }

--- a/src/main/java/com/track/fin/service/TransactionService.java
+++ b/src/main/java/com/track/fin/service/TransactionService.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.track.fin.type.ErrorCode.*;
 import static com.track.fin.type.TransactionResultType.FAIL;
@@ -67,35 +66,58 @@ public class TransactionService {
     }
 
     @Transactional(readOnly = true)
-    public List<TransactionDto> getTransactionsByAccount(
+    public List<TransferResponseRecord> getTransferTransactionsByAccount(
             String accountNumber,
             LocalDateTime startDate,
             LocalDateTime endDate,
-            List<TransactionType> types,
             boolean sortDesc
     ) {
-        Account account = accountRepository.findByAccountNumber(accountNumber)
+        Account account = getAccountByNumber(accountNumber);
+        List<Transaction> transfers = getTransferTransactions(account, startDate, endDate);
+        List<TransferResponseRecord> results = convertToTransferRecords(transfers, accountNumber);
+        sortTransferRecords(results, sortDesc);
+        return results;
+    }
+
+    private Account getAccountByNumber(String accountNumber) {
+        return accountRepository.findByAccountNumber(accountNumber)
                 .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+    }
 
-        List<Transaction> transactions = (types == null || types.isEmpty()) ?
-                transactionRepository.findByAccountAndTransactionDateBetween(
-                        account, startDate, endDate
-                )
-                : transactionRepository.findByAccountAndTransactionDateBetweenAndTransactionTypeIn(
-                account, startDate, endDate, types
+    private List<Transaction> getTransferTransactions(Account account, LocalDateTime start, LocalDateTime end) {
+        return transactionRepository.findByAccountAndTransactionTypeAndTransactionDateBetween(
+                account, TransactionType.TRANSFER, start, end
         );
+    }
 
-        transactions.sort((a, b) -> {
-            if (sortDesc) {
-                return b.getTransactionDate().compareTo(a.getTransactionDate());
-            } else {
-                return a.getTransactionDate().compareTo(b.getTransactionDate());
+    private List<TransferResponseRecord> convertToTransferRecords(List<Transaction> transactions, String accountNumber) {
+        List<TransferResponseRecord> result = new ArrayList<>();
+
+        for (int i = 0; i < transactions.size() - 1; i++) {
+            Transaction t1 = transactions.get(i);
+            Transaction t2 = transactions.get(i + 1);
+
+            if (isValidTransferPair(t1, t2)) {
+                Transaction from = t1.getAccount().getAccountNumber().equals(accountNumber) ? t1 : t2;
+                Transaction to = from == t1 ? t2 : t1;
+
+                result.add(TransferResponseRecord.from(from, to));
+                i++;
             }
-        });
+        }
 
-        return transactions.stream()
-                .map(TransactionDto::fromEntity)
-                .collect(Collectors.toList());
+        return result;
+    }
+
+    private boolean isValidTransferPair(Transaction t1, Transaction t2) {
+        return !t1.getAccount().getAccountNumber().equals(t2.getAccount().getAccountNumber()) &&
+                Objects.equals(t1.getAmount(), t2.getAmount());
+    }
+
+    private void sortTransferRecords(List<TransferResponseRecord> list, boolean sortDesc) {
+        list.sort((a, b) -> sortDesc
+                ? b.transactionDate().compareTo(a.transactionDate())
+                : a.transactionDate().compareTo(b.transactionDate()));
     }
 
     public void saveFailedUseTransaction(String accountNumber, Long amount) {
@@ -105,7 +127,7 @@ public class TransactionService {
     }
 
     @Transactional
-    public TransactionDto cancelBalance(String transactionId, String accountNumber, Long amount) {
+    public TransferResponseRecord cancelBalance(String transactionId, String accountNumber, Long amount) {
         Transaction transaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new AccountException(TRANSACTION_NOT_FOUND));
         Account account = accountRepository.findByAccountNumber(accountNumber)
@@ -114,7 +136,8 @@ public class TransactionService {
         validateCancelBalance(transaction, account, amount);
         account.useBalance(amount);
 
-        return TransactionDto.fromEntity(saveAndGetTransaction(DEPOSIT, SUCCESS, account, amount));
+        Transaction newTransaction = saveAndGetTransaction(DEPOSIT, SUCCESS, account, amount);
+        return TransferResponseRecord.from(newTransaction);
     }
 
     public void saveFailedCancelTransaction(String accountNumber, Long amount) {
@@ -123,12 +146,12 @@ public class TransactionService {
         saveAndGetTransaction(DEPOSIT, FAIL, account, amount);
     }
 
-    public TransactionDto queryTransactionId(String transactionId) {
-        return TransactionDto.fromEntity(
-                transactionRepository.findById(transactionId)
-                        .orElseThrow(() -> new AccountException(TRANSACTION_NOT_FOUND))
-        );
+    public TransferResponseRecord queryTransactionId(String transactionId) {
+        Transaction transaction = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new AccountException(TRANSACTION_NOT_FOUND));
+        return TransferResponseRecord.from(transaction);
     }
+
 
     private void validateCancelBalance(Transaction transaction, Account account, Long amount) {
         if (!Objects.equals(transaction.getAccount().getId(), account.getId())) {

--- a/src/main/java/com/track/fin/type/ErrorCode.java
+++ b/src/main/java/com/track/fin/type/ErrorCode.java
@@ -23,7 +23,16 @@ public enum ErrorCode {
     FEE_NOT_FOUND("수수료 정보가 존재하지 않습니다."),
     INSUFFICIENT_BALANCE("잔액이 부족합니다."),
     MAX_DEPOSIT_LIMIT_EXCEEDED("입금 한도를 초과했습니다."),
-    LOAN_NOT_FOUND("대출 찾을 수 없습니다.");
+    LOAN_NOT_FOUND("대출 찾을 수 없습니다."),
+    AUTO_TRANSFER_ACTIVE("자동이체가 등록된 계좌입니다."),
+    LOAN_EXISTS("미결제 대출이 존재합니다."),
+    AUTO_TRANSFER_EXISTS("자동이체가 등록된 계좌입니다."),
+    WITHDRAW_ACCOUNT_NOT_PROVIDED("출금 계좌가 등록되지 않았습니다."),
+    WITHDRAW_ACCOUNT_UNMATCH("출금 계좌가 사용자와 일치하지 않습니다."),
+    WITHDRAW_ACCOUNT_INACTIVE("출금 계좌가 해지 상태입니다."),
+    CANNOT_CREATE_ACCOUNT_DUE_TO_RECENT_CLOSURE("해지된 계좌가 있어 1개월 내 신규 계좌 개설이 제한됩니다."),
+
+    ;
 
     private final String description;
 

--- a/src/main/java/com/track/fin/type/LoanStatus.java
+++ b/src/main/java/com/track/fin/type/LoanStatus.java
@@ -4,5 +4,8 @@ public enum LoanStatus {
 
     SUCCESS,
     FAIL,
+    ONGOING,
+    DELINQUENT,
+    REPAID,
 
 }


### PR DESCRIPTION

## #️⃣ Issue Number
- #26 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 개발 상세 내역

### ✅ 1. 계좌 해지 조건 처리
- 미결제 대출, 자동이체가 존재하면 계좌 해지 제한
- 잔액이 존재하면 등록된 출금 계좌로 자동 송금
- 출금 계좌 미등록/비활성 시 해지 제한

### ✅ 2. 계좌 해지 후 신규 계좌 개설 제한
- 해지일로부터 1개월 이내인 경우 계좌 개설 불가
- Account의 unregisteredAt 기반으로 검증

### ✅ 3. 거래 내역 조회 기능
- 계좌별 거래내역 조회 시
  - 기간 필터 적용 (기본 1개월)
  - 거래유형 필터 적용 (입금, 출금, 대출, 자동이체 등)
  - 정렬 방식 지원 (최신순, 오래된 순)
- GET /transaction/{accountNumber} 엔드포인트 추가
 
### ✅ 4. ENUM  ERRORCODE추가
- AUTO_TRANSFER_ACTIVE("자동이체가 등록된 계좌입니다."),
- LOAN_EXISTS("미결제 대출이 존재합니다."),
-  AUTO_TRANSFER_EXISTS("자동이체가 등록된 계좌입니다."),
- WITHDRAW_ACCOUNT_NOT_PROVIDED("출금 계좌가 등록되지 않았습니다."),
- WITHDRAW_ACCOUNT_UNMATCH("출금 계좌가 사용자와 일치하지 않습니다."),
- WITHDRAW_ACCOUNT_INACTIVE("출금 계좌가 해지 상태입니다."),
-  CANNOT_CREATE_ACCOUNT_DUE_TO_RECENT_CLOSURE("해지된 계좌가 있어 1개월 내 신규 계좌 개설이 제한됩니다."),